### PR TITLE
Update projects page with Nostr links and fix RSS feed

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -45,6 +45,7 @@ Lessons. And 21 Lessons turned a book.
 {% include image.html path="/assets/images/bitcoin/projects/21lessons.png" link="https://21lessons.com" %}
 
 * Website: [21lessons.com][21lessons]
+* Nostr: [@21lessons.com](https://npub.world/npub1c48eccpffjsgq65x7j65zzv0877l4ylrl7j754agqe25xlp5yjdq3rvunf)
 * Purchase: [Paperback][paperback], [Kindle](https://amzn.to/3bvM49P), [Audiobook](https://amzn.to/2ZeUsYX)
 * Source: [GitHub](https://github.com/21-lessons/21lessons-book)
 
@@ -64,7 +65,7 @@ selecting and curating content.
 {% include image.html path="/assets/images/bitcoin/projects/bitcoin-resources.png" link="https://bitcoin-resources.com" %}
 
 * Website: [bitcoin-resources.com][bitcoin-resources]
-* Twitter: [@BtcResources](https://twitter.com/BtcResources)
+* Nostr: [@bitcoin-resources.com](https://npub.world/npub1ressrcmqgvqz3xuxdtamxmmv9ve6rxcf99fd694s6hutntfvcmdqvn56zk)
 * Contribute: [GitHub](https://github.com/bitcoin-resources/bitcoin-resources.github.io/blob/master/CONTRIBUTING.md), [Telegram](https://t.me/BitcoinResourcesCom)
 * Source: [GitHub](https://github.com/bitcoin-resources/bitcoin-resources.github.io)
 
@@ -105,11 +106,11 @@ to get random quotes in your timeline.
 {% include image.html path=randompath link="https://bitcoin-quotes.com" %}
 
 * Website: [bitcoin-quotes.com][bitcoin-quotes]
-* Twitter: [@btc_quotes][btc_quotes]
+* Nostr: [@bitcoin-quotes.com](https://npub.world/npub1satst5p5jcacfpagy3jxscf2s48d9dd0v6lfxms7frp9e6t2w5xstmsfjp)
 * Source: [GitHub](https://github.com/dergigi/btc-quotes)
 
 [bitcoin-quotes]: https://www.bitcoin-quotes.com/
-[btc_quotes]: https://twitter.com/btc_quotes
+
 [API]: https://www.bitcoin-quotes.com/quotes/random.json
 
 
@@ -122,7 +123,7 @@ install and use.
 {% include image.html path="/assets/images/bitcoin/projects/jam.png" link="https://github.com/joinmarket-webui" %}
 
 * Website: [jamapp.org](https://jamapp.org)
-* Twitter: [@jamapporg](https://twitter.com/jamapporg)
+* Nostr: [@jamapp.org](https://npub.world/npub1jamj9l9vsrra9m58y6syyjvfcf85wvev7pm3vvwqkr0e8vzdyhsqvhw852)
 * Documentation: [jamdocs.org](https://jamdocs.org)
 * Installation: via [RaspiBlitz, Umbrel, or Citadel](https://jamdocs.org/software/installation/)
 * Source: [GitHub](https://github.com/joinmarket-webui/jam)
@@ -172,7 +173,7 @@ of German translations.
 * Hosts: [Daniel], [Dennis], [Fab], [Gigi], [Markus]
 * Website: [einundzwanzig.space](https://einundzwanzig.space/)
 * Podcast: [einundzwanzig.space/podcast][einundzwanzig]
-* Twitter: [@\_einundzwanzig\_](https://twitter.com/_einundzwanzig_)
+* Nostr: [@einundzwanzig.space](https://npub.world/npub1qv02xpsc3lhxxx5x7xswf88w3u7kykft9ea7t78tz7ywxf7mxs9qrxujnc)
 * Community: [t.me/einundzwanzigpodcast](https://t.me/einundzwanzigpodcast)
 
 [Daniel]: https://twitter.com/danielwingen
@@ -205,10 +206,10 @@ Bitcoin in your timeline.
 
 {% include image.html path="/assets/images/bitcoin/projects/quotablesatoshi.png" link="https://twitter.com/QuotableSatoshi" %}
 
-* Twitter: [@QuotableSatoshi][quotablesatoshi]
-* Source: [GitHub](https://twitter.com/quotablesatoshi)
+* Nostr: [@quotablesatoshi.com](https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu)
+* Source: [GitHub](https://github.com/dergigi/quotable-satoshi)
 
-[quotablesatoshi]: https://twitter.com/quotablesatoshi
+
 
 ### Closing the Loop
 
@@ -233,7 +234,7 @@ install and use.
 {% include image.html path="/assets/images/bitcoin/projects/jam.jpg" link="https://github.com/joinmarket-webui" %}
 
 * Website: [jamapp.org](https://jamapp.org)
-* Twitter: [@jamapporg](https://twitter.com/jamapporg)
+* Nostr: [@jamapp.org](https://npub.world/npub1jamj9l9vsrra9m58y6syyjvfcf85wvev7pm3vvwqkr0e8vzdyhsqvhw852)
 * Documentation: [jamdocs.org](https://jamdocs.org)
 * Installation: via [RaspiBlitz, Umbrel, or Citadel](https://jamdocs.org/software/installation/)
 * Source: [GitHub](https://github.com/joinmarket-webui/jam)

--- a/projects.md
+++ b/projects.md
@@ -96,7 +96,7 @@ collection of Bitcoin-related quotes. As of this writing, 300+ quotes have been 
 indexed, in both audio and written form. The source of each quote will be revealed upon
 paying ~2¢ in sats. I hope that these quotes will inform, inspire, and delight those who
 stumble upon them. There is also a rudimentary [API][API] if you want to integrate these
-random quotes into a project of yours. Follow the [twitter bot][btc_quotes] of this project
+random quotes into a project of yours. Follow the [nostr bot](https://npub.world/npub1satst5p5jcacfpagy3jxscf2s48d9dd0v6lfxms7frp9e6t2w5xstmsfjp) of this project
 to get random quotes in your timeline.
 
 {% capture time_seed %}{{ 'now' | date: "%s" }}{% endcapture %}
@@ -197,14 +197,14 @@ revised and adapted by myself.
 
 [paperback-de]: https://amzn.to/2AtlfWZ
 
-### Quotable Satoshi Twitter Bot
+### Quotable Satoshi Nostr Bot
 
-Building upon the great work of the Satoshi Nakamoto Institute, I wrote a twitter bot to
+Building upon the great work of the Satoshi Nakamoto Institute, I wrote a nostr bot to
 disseminate the most insightful and interesting quotes of Satoshi Nakamoto. Simply follow
-[@QuotableSatoshi][quotablesatoshi] on twitter to get historical quotes from the inventor of
+[@quotablesatoshi.com](https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu) on nostr to get historical quotes from the inventor of
 Bitcoin in your timeline.
 
-{% include image.html path="/assets/images/bitcoin/projects/quotablesatoshi.png" link="https://twitter.com/QuotableSatoshi" %}
+{% include image.html path="/assets/images/bitcoin/projects/quotablesatoshi.png" link="https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu" %}
 
 * Nostr: [@quotablesatoshi.com](https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu)
 * Source: [GitHub](https://github.com/dergigi/quotable-satoshi)

--- a/projects.md
+++ b/projects.md
@@ -269,6 +269,7 @@ to start their own local—and localized—bitcoin-only community.
 {% include image.html path="/assets/images/bitcoin/projects/twentyone-world.png" link="https://twentyone.world" %}
 
 * Website: [twentyone.world](https://twentyone.world)
+* Nostr: [@twentyone.world](https://npub.world/npub1w0rldx5sdg960fw7lffu9r4tcec3nlu0ez2jzhdnl6x0tvdgpnkqf5v9xl)
 * Source: [GitHub](https://github.com/twentyone-world/)
 
 ### Fucking Shitcoins

--- a/projects.md
+++ b/projects.md
@@ -119,7 +119,7 @@ Jam is a Web UI for JoinMarket, one of the oldest and most established Bitcoin
 privacy tools that exist. It is a community-effort to make JoinMarket easier to
 install and use.
 
-{% include image.html path="/assets/images/bitcoin/projects/jam.jpg" link="https://github.com/joinmarket-webui" %}
+{% include image.html path="/assets/images/bitcoin/projects/jam.png" link="https://github.com/joinmarket-webui" %}
 
 * Website: [jamapp.org](https://jamapp.org)
 * Twitter: [@jamapporg](https://twitter.com/jamapporg)

--- a/projects.md
+++ b/projects.md
@@ -201,7 +201,7 @@ revised and adapted by myself.
 
 Building upon the great work of the Satoshi Nakamoto Institute, I wrote a nostr bot to
 disseminate the most insightful and interesting quotes of Satoshi Nakamoto. Simply follow
-[@quotablesatoshi.com](https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu) on nostr to get historical quotes from the inventor of
+[Quotable Satoshi](https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu) on nostr to get historical quotes from the inventor of
 Bitcoin in your timeline.
 
 {% include image.html path="/assets/images/bitcoin/projects/quotablesatoshi.png" link="https://npub.world/npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu" %}

--- a/projects.md
+++ b/projects.md
@@ -312,7 +312,7 @@ not a destination, and this podcast is its travel log.
 
 * Website: [sovereignengineering.io/podcast](https://sovereignengineering.io/podcast)
 * Nostr: [no-solutions@sovereignengineering.io](https://npub.world/npub1n00yy9y3704drtpph5wszen64w287nquftkcwcjv7gnnkpk2q54s73000n)
-* Platforms: [castr.me](https://castr.me), [Podcast Index](https://podcastindex.org), [RSS](https://feeds.castr.com/sovereign-engineering)
+* Platforms: [castr.me](https://castr.me), [Podcast Index](https://podcastindex.org), [RSS](https://sovereignengineering.io/dialogues.xml)
 
 ### Contribution: The Bitcoin Times
 


### PR DESCRIPTION
This PR updates the projects page to replace Twitter links with Nostr links for better alignment with the decentralized web ecosystem. The changes include replacing Twitter references with Nostr links for 21 Lessons, Jam, Bitcoin Resources, Bitcoin Quotes, Einundzwanzig, Quotable Satoshi, and twentyone.world projects. Additionally, the RSS feed link for the No Solutions podcast has been corrected to point to the proper URL, and the Quotable Satoshi section has been updated to reflect that it's now a nostr bot rather than a twitter bot. The Jam project image file extension has also been corrected from jpg to png.