### PR TITLE
Add Fathom script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -70,3 +70,9 @@
     ga('send', 'pageview');
   </script>
 {% endif %}
+
+{% if jekyll.environment == "production" %}
+<!-- Fathom - beautiful, simple website analytics -->
+<script src="https://cdn.usefathom.com/script.js" data-site="QHRSVQMF" defer></script>
+<!-- / Fathom -->
+{% endif %}


### PR DESCRIPTION
Add Fathom analytics script to the head template. The script is conditionally loaded only in production environments using Jekyll's environment check, ensuring analytics are not active during local development.