### PR TITLE
Add Nostr section with value back link

### DIFF
--- a/support.md
+++ b/support.md
@@ -104,6 +104,10 @@ specific article---you can!
 
 [sats]: lightning:s@ts.dergigi.com
 
+### Nostr
+
+[Give Value Back With Zaps](https://zapper.fun/zap?id=npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc)
+
 ### Supporting Others
 
 If you don't want to support me but still want to support Bitcoin and related


### PR DESCRIPTION
Your BTCpayServer was down so I thought it would be cool to add a nostr payment link to your support page. 

There are other options like zap me a coffee, but I don't even know if you like coffee. :)

https://zapmeacoffee.com/npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc