### PR TITLE
feat(ai): add /ai filter page and normalize tag casing

### DIFF
--- a/_includes/posts-grid.html
+++ b/_includes/posts-grid.html
@@ -1,0 +1,11 @@
+{% assign posts = include.posts %}
+<div class="posts">
+  <div class="grid-xlarge">
+    <div class="posts__container" itemscope itemtype="http://schema.org/Blog" data-columns>
+      {% for post in posts %}
+        {% include post-card.html %}
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% include article-list.html posts=posts %}

--- a/ai/index.html
+++ b/ai/index.html
@@ -1,0 +1,11 @@
+---
+layout: default
+title: AI
+subtitle: On machines that write.
+tags:
+- ai
+---
+{% assign aiposts = site.posts | where_exp: "p", "p.tags contains 'ai'" %}
+<div class="post__content section-padding">
+  {% include posts-grid.html posts=aiposts %}
+</div>

--- a/bitcoin/index.html
+++ b/bitcoin/index.html
@@ -8,16 +8,7 @@ layout: default
       Don't know what bitcoin is? Have a look at <a href="https://bitcoin-resources.com" target="_blank">bitcoin-resources.com</a>
     </p>
   </div>
-  <div class="posts">
-    <div class="grid-xlarge">
-      <div class="posts__container" itemscope itemtype="http://schema.org/Blog" data-columns>
-        {% for post in bitcoinposts %}
-          {% include post-card.html %}
-        {% endfor %}
-      </div>
-    </div>
-  </div>
-  {% include article-list.html posts=bitcoinposts %}
+  {% include posts-grid.html posts=bitcoinposts %}
   <div id="markdown" class="grid">
     <hr/>
     <p>

--- a/blog/index.html
+++ b/blog/index.html
@@ -2,16 +2,5 @@
 layout: default
 redirect_from: photography
 ---
-<!-- The main content area -->
 {% assign blogposts = site.categories.photography %}
-<div class="posts">
-  <div class="grid-xlarge">
-    <div class="posts__container" itemscope itemtype="http://schema.org/Blog" data-columns>
-
-      {% for post in blogposts %}
-        {% include post-card.html %}
-      {% endfor %}
-    </div>
-  </div>
-  {% include article-list.html posts=blogposts %}
-</div>
+{% include posts-grid.html posts=blogposts %}

--- a/collections/_posts/2019-05-21-words.markdown
+++ b/collections/_posts/2019-05-21-words.markdown
@@ -10,6 +10,7 @@ category: photography
 tags:
   - Photography
   - Travel
+  - Writing
 ---
 
 Words have to be one of the greatest inventions of mankind. Granted, it's a

--- a/collections/_posts/2021-12-08-tyranny.markdown
+++ b/collections/_posts/2021-12-08-tyranny.markdown
@@ -9,6 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
+  - Writing
 translations:
  - language: German
    url: https://telegra.ph/Tyrannei-01-05

--- a/collections/_posts/2022-09-25-creativity.markdown
+++ b/collections/_posts/2022-09-25-creativity.markdown
@@ -9,7 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
-  - AI
+  - ai
 ---
 
 Creativity is a mystery. It is creation, inspiration, and—of

--- a/collections/_posts/2023-03-28-hesitancy.markdown
+++ b/collections/_posts/2023-03-28-hesitancy.markdown
@@ -9,6 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
+  - Writing
 ---
 
 Hesitancy tells you something. I'm not sure what it is, exactly, but it is something. If there wouldn't be something there would be no hesitancy, all there would be is "fuck yes," followed by immediate action.

--- a/collections/_posts/2023-05-04-writing.markdown
+++ b/collections/_posts/2023-05-04-writing.markdown
@@ -9,6 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
+  - Writing
 ---
 
 Writing, for some reason, is one of the most powerful things you can do.

--- a/collections/_posts/2024-02-03-lethargy.markdown
+++ b/collections/_posts/2024-02-03-lethargy.markdown
@@ -9,6 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
+  - Writing
 ---
 
 Lethargy. A state of comatose torpor. Oh, what beautiful words. Oh, what a

--- a/collections/_posts/2024-02-04-reality.markdown
+++ b/collections/_posts/2024-02-04-reality.markdown
@@ -9,6 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
+  - Writing
 ---
 
 Reality is that which, when you stop believing in it, doesn't go away. At least

--- a/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
+++ b/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
@@ -9,6 +9,7 @@ author: Gigi
 category: photography
 tags:
   - Photography
+  - Writing
 ---
 
 > We may enjoy our room in the tower, with the painted walls and the commodious

--- a/collections/bitcoin/_posts/2025-10-31-building-boris.md
+++ b/collections/bitcoin/_posts/2025-10-31-building-boris.md
@@ -13,7 +13,7 @@ favorite: false
 tags:
 - Writing
 - Vibing
-- AI
+- ai
 - nostr
 boris_link: https://read.withboris.com/a/naddr1qq8xyatfd3jxjmn8943x7unfwvpzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqvzqqqr4gul0rszl
 ---

--- a/collections/bitcoin/_posts/2026-03-20-the-internet-left-me.md
+++ b/collections/bitcoin/_posts/2026-03-20-the-internet-left-me.md
@@ -9,8 +9,8 @@ redirect_from: "/internet"
 author: Gigi
 category: bitcoin
 tags:
-- Nostr
-- AI
+- nostr
+- ai
 - Writing
 boris_link: https://read.withboris.com/a/naddr1qq28g6r9945kuar9wfhx2apdd3jkvapdd4jsygrwg6zz9hahfftnsup23q3mnv5pdz46hpj4l2ktdpfu6rhpthhwjvpsgqqqw4rsenast8
 ---

--- a/collections/bitcoin/_posts/2026-03-22-caring-about-sloppypasta.md
+++ b/collections/bitcoin/_posts/2026-03-22-caring-about-sloppypasta.md
@@ -9,8 +9,8 @@ redirect_from: "/sloppypasta"
 author: Gigi
 category: bitcoin
 tags:
-- Nostr
-- AI
+- nostr
+- ai
 - Writing
 boris_link: https://read.withboris.com/a/naddr1qqvxxctjd9hxwttpvfhh2apdwdkx7urs09cxzum5vypzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqvzqqqr4guh8g5l0
 ---

--- a/nostr/index.html
+++ b/nostr/index.html
@@ -5,12 +5,7 @@ subtitle: The bird app is dead, long live the bird app!
 tags:
 - nostr
 ---
-{% assign nostrposts = "" | split: "," %}
-{% for post in site.posts %}
-  {% if post.tags contains "nostr" %}
-    {% assign nostrposts = nostrposts | push: post %}
-  {% endif %}
-{% endfor %}
+{% assign nostrposts = site.posts | where_exp: "p", "p.tags contains 'nostr'" %}
 <div class="post__content section-padding">
   <div id="markdown" class="grid">
     <p>
@@ -37,14 +32,5 @@ tags:
       </pre>
     </p>
   </div>
-  <div class="posts">
-    <div class="grid-xlarge">
-      <div class="posts__container" itemscope itemtype="http://schema.org/Blog" data-columns>
-        {% for post in nostrposts %}
-          {% include post-card.html %}
-        {% endfor %}
-      </div>
-    </div>
-  </div>
-  {% include article-list.html posts=nostrposts %}
+  {% include posts-grid.html posts=nostrposts %}
 </div>

--- a/words.html
+++ b/words.html
@@ -8,8 +8,9 @@ layout: default
       You can filter the below via 
       <a href="{{ 'blog' | absolute_url }}">/blog</a>,
       <a href="{{ 'bitcoin' | absolute_url }}">/bitcoin</a>,
+      <a href="{{ 'nostr' | absolute_url }}">/nostr</a>,
       and
-      <a href="{{ 'nostr' | absolute_url }}">/nostr</a>.
+      <a href="{{ 'ai' | absolute_url }}">/ai</a>.
       <br/>There is also <a href="{{ 'threads' | absolute_url }}">/threads</a>.
     </p>
     <hr/>


### PR DESCRIPTION
Adds a new `/ai` filter page that surfaces AI-tagged posts (mirroring the tag-based `/nostr` pattern), extracts a shared `_includes/posts-grid.html` so `/blog`, `/bitcoin`, `/nostr`, and `/ai` all render through one include, and normalizes tag casing so case-sensitive Liquid `contains` filters work correctly. Also tags a handful of essay-style posts in the photography collection with `Writing` so their content is reflected accurately.

- New `/ai` filter at `ai/index.html`, linked from `words.html` alongside `/blog`, `/bitcoin`, and `/nostr`
- Shared `_includes/posts-grid.html` replaces duplicated grid markup across the filter pages; `/nostr` now uses a single `where_exp` instead of a manual loop
- Tag casing normalized to lowercase `nostr` and `ai`, which also fixes a latent bug where `/nostr` silently missed posts tagged `Nostr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new AI content section to browse AI-related posts.
  * Introduced "Writing" tag for organizing written content across the site.

* **Improvements**
  * Standardized tag formatting for consistency.
  * Unified post grid layouts across blog sections for a cohesive browsing experience.
  * Updated navigation filters to include the new AI section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->