### PR TITLE
fix: add Binance Chain failure to PoS page

### DIFF
--- a/pos.md
+++ b/pos.md
@@ -52,6 +52,7 @@ If you are more on the academic side of things, here are some papers:
 
 Some recent failures include:
 
+- **2023-01-02** - [Binance Chain breaks every 24 hours][binance-restart], relying on a [state recover tool][binance-state-recover] to reset node state and continue from a chosen height
 - **2022-05-27** [Solana's blockchain clock loses track of time][sol-clock], now running 30 minutes behind (see [Lesson 17][L17] and [Bitcoin is Time][time])
 - **2022-06-19** - Solana: [1 vote][sol-vote-img], making up 90% of total votes, [decided the fate][sol-vote] of ~$270m in users assets
 - **2020-03-18** - [STEEM][steem-details]: adversarial takeover by Justin Sun, resulting in [a hard fork][steem-hf] that is now Hive ([timeline][steem-timeline], [details][steem-details]).
@@ -60,6 +61,8 @@ For some not-so-recent failures, see [this thread by Alex B][bergealex].
 
 [L17]: https://21lessons.com/17/
 
+[binance-restart]: https://medium.com/chainargos/binance-built-a-blockchain-except-it-didnt-5759224ba7aa
+[binance-state-recover]: https://github.com/bnb-chain/node/blob/master/networks/tools/state_recover/state_recover.go
 [sol-clock]: https://archive.ph/jlVn4
 [sol-vote]: https://archive.ph/f3boB
 [sol-vote-img]: {{ site.url }}/assets/images/shitcoins/sol-vote.jpg


### PR DESCRIPTION
Adds the Binance Chain 24-hour breakage example to `/pos` and links both the ChainArgos write-up and the upstream `state_recover` tool so the failures list covers the case raised in #445.

Fixes #445.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated incident documentation to include a recent Binance Chain restart event from 2023-01-02, detailing the state recovery procedures utilized during the incident.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dergigi/dergigi.github.io/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->