### PR TITLE
Add recent podcast appearances and talks to /media

### DIFF
--- a/collections/_episodes/20190821-euzz.md
+++ b/collections/_episodes/20190821-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-08-21
+podname: EINUNDZWANZIG
+topics: Es gibt Bitcoin, und es gibt Shitcoins
+guests: 
+host: 
+abbrev: EUZZ
+sode: 1
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-01-es-gibt-bitcoin-und-es-gibt-shitcoins/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20190828-euzz.md
+++ b/collections/_episodes/20190828-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-08-28
+podname: EINUNDZWANZIG
+topics: Selbst der Dümmste erkennt, dass hier nur Geld gedruckt wird
+guests: 
+host: 
+abbrev: EUZZ
+sode: 2
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-02-selbst-der-duemmste-erkennt-dass-hier-nur-geld-gedruckt-wird/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20190905-euzz.md
+++ b/collections/_episodes/20190905-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-09-05
+podname: EINUNDZWANZIG
+topics: Morgenstund' hat Bitcoin im Mund
+guests: 
+host: 
+abbrev: EUZZ
+sode: 3
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-03-morgenstund-hat-bitcoin-im-mund/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20190911-euzz.md
+++ b/collections/_episodes/20190911-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-09-11
+podname: EINUNDZWANZIG
+topics: Wale und physische Bitcoins
+guests: 
+host: 
+abbrev: EUZZ
+sode: 4
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-04-wale-und-physische-bitcoins/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20191030-euzz.md
+++ b/collections/_episodes/20191030-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-10-30
+podname: EINUNDZWANZIG
+topics: Wiedergeburt
+guests: 
+host: 
+abbrev: EUZZ
+sode: 5
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-05-wiedergeburt/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20191106-euzz.md
+++ b/collections/_episodes/20191106-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-11-06
+podname: EINUNDZWANZIG
+topics: The Wolf of Bitcoinstreet
+guests: 
+host: 
+abbrev: EUZZ
+sode: 6
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-06-the-wolf-of-bitcoinstreet/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20191120-euzz.md
+++ b/collections/_episodes/20191120-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-11-20
+podname: EINUNDZWANZIG
+topics: Ein Huhn kostet 185135 Satoshis
+guests: 
+host: 
+abbrev: EUZZ
+sode: 8
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-08-ein-huhn-kostet-185135-satoshis/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20191127-euzz.md
+++ b/collections/_episodes/20191127-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2019-11-27
+podname: EINUNDZWANZIG
+topics: Diese modernen Bitcoin-Menschen
+guests: 
+host: 
+abbrev: EUZZ
+sode: 9
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-09-diese-modernen-bitcoin-menschen/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200108-euzz.md
+++ b/collections/_episodes/20200108-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-01-08
+podname: EINUNDZWANZIG
+topics: Honigdachs in the house
+guests: 
+host: 
+abbrev: EUZZ
+sode: 15
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-15-honigdachs-in-the-house/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200116-euzz.md
+++ b/collections/_episodes/20200116-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-01-16
+podname: EINUNDZWANZIG
+topics: Shitcoin Trading im Turm
+guests: 
+host: 
+abbrev: EUZZ
+sode: 16
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-16-shitcoin-trading-im-turm/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200123-euzz.md
+++ b/collections/_episodes/20200123-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-01-23
+podname: EINUNDZWANZIG
+topics: Doktortitel sind intrinsisch wertlos
+guests: 
+host: 
+abbrev: EUZZ
+sode: 17
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-17-doktortitel-sind-intrinsisch-wertlos/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200206-euzz.md
+++ b/collections/_episodes/20200206-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-02-06
+podname: EINUNDZWANZIG
+topics: 500 Millionen Millisekunden
+guests: 
+host: 
+abbrev: EUZZ
+sode: 19
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-19-500-millionen-millisekunden/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200213-euzz.md
+++ b/collections/_episodes/20200213-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-02-13
+podname: EINUNDZWANZIG
+topics: Topologien sozialer Bitcoin-Wesen mit Rene Pickhardt
+guests: 
+host: 
+abbrev: EUZZ
+sode: 20
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-20-topologien-sozialer-bitcoin-wesen-mit-rene-pickhardt/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200220-euzz.md
+++ b/collections/_episodes/20200220-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-02-20
+podname: EINUNDZWANZIG
+topics: Die unendlichen Weiten des Bitcoin
+guests: 
+host: 
+abbrev: EUZZ
+sode: 21
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-21-die-unendlichen-weiten-des-bitcoin/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200304-euzz.md
+++ b/collections/_episodes/20200304-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-03-04
+podname: EINUNDZWANZIG
+topics: Euro-Cost-Averaging gegen den Endboss
+guests: 
+host: 
+abbrev: EUZZ
+sode: 23
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-23-euro-cost-averaging-gegen-den-endboss/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200507-euzz.md
+++ b/collections/_episodes/20200507-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-05-07
+podname: EINUNDZWANZIG
+topics: Pre-Halving!
+guests: 
+host: 
+abbrev: EUZZ
+sode: 31
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-31-pre-halving/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200520-euzz.md
+++ b/collections/_episodes/20200520-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-05-20
+podname: EINUNDZWANZIG
+topics: Das Digitale Drucken der Dollar-Trillionen
+guests: 
+host: 
+abbrev: EUZZ
+sode: 32
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-32-das-digitale-drucken-der-dollar-trillionen/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200603-euzz.md
+++ b/collections/_episodes/20200603-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-06-03
+podname: EINUNDZWANZIG
+topics: Der vorprogrammierte Mond und die spirituelle Zitadelle
+guests: 
+host: 
+abbrev: EUZZ
+sode: 34
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-34-der-vorprogrammierte-mond-und-die-spirituelle-zitadelle/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200701-euzz.md
+++ b/collections/_episodes/20200701-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-07-01
+podname: EINUNDZWANZIG
+topics: Göttliche Grants
+guests: 
+host: 
+abbrev: EUZZ
+sode: 38
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-38-goettliche-grants/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200722-euzz.md
+++ b/collections/_episodes/20200722-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-07-22
+podname: EINUNDZWANZIG
+topics: Bitcoin from Heaven
+guests: 
+host: 
+abbrev: EUZZ
+sode: 41
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-41-bitcoin-from-heaven/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200730-euzz.md
+++ b/collections/_episodes/20200730-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-07-30
+podname: EINUNDZWANZIG
+topics: Bitcoin ist die Antwort
+guests: 
+host: 
+abbrev: EUZZ
+sode: 42
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-42-bitcoin-ist-die-antwort/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200826-euzz.md
+++ b/collections/_episodes/20200826-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-08-26
+podname: EINUNDZWANZIG
+topics: Lass Bitcoin laufen statt im Fiat zu ersaufen
+guests: 
+host: 
+abbrev: EUZZ
+sode: 46
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-46-lass-bitcoin-laufen-statt-im-fiat-zu-ersaufen/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20200909-euzz.md
+++ b/collections/_episodes/20200909-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-09-09
+podname: EINUNDZWANZIG
+topics: Block Lives Matter
+guests: 
+host: 
+abbrev: EUZZ
+sode: 48
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-48-block-lives-matter/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20201105-euzz.md
+++ b/collections/_episodes/20201105-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-11-05
+podname: EINUNDZWANZIG
+topics: Zitadellen sind Echokammern
+guests: 
+host: 
+abbrev: EUZZ
+sode: 56
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-56-zitadellen-sind-echokammern/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20201118-euzz.md
+++ b/collections/_episodes/20201118-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-11-18
+podname: EINUNDZWANZIG
+topics: Das unendliche Gulasch
+guests: 
+host: 
+abbrev: EUZZ
+sode: 58
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-58-das-unendliche-gulasch/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20201126-euzz.md
+++ b/collections/_episodes/20201126-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-11-26
+podname: EINUNDZWANZIG
+topics: Befreit die Sats!
+guests: 
+host: 
+abbrev: EUZZ
+sode: 59
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-59-befreit-die-sats/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20201202-euzz.md
+++ b/collections/_episodes/20201202-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-12-02
+podname: EINUNDZWANZIG
+topics: Niemand ist immun
+guests: 
+host: 
+abbrev: EUZZ
+sode: 60
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-60-niemand-ist-immun/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20201224-euzz.md
+++ b/collections/_episodes/20201224-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-12-24
+podname: EINUNDZWANZIG
+topics: Frohe All-Time-Highnachten!
+guests: 
+host: 
+abbrev: EUZZ
+sode: 63
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-63-frohe-all-time-highnachten/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20201230-euzz.md
+++ b/collections/_episodes/20201230-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2020-12-30
+podname: EINUNDZWANZIG
+topics: Panzerknackersyndrom
+guests: 
+host: 
+abbrev: EUZZ
+sode: 64
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-64-panzerknackersyndrom/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210120-euzz.md
+++ b/collections/_episodes/20210120-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-01-20
+podname: EINUNDZWANZIG
+topics: Es brennt im Iglu
+guests: 
+host: 
+abbrev: EUZZ
+sode: 67
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-67-es-brennt-im-iglu/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210128-euzz.md
+++ b/collections/_episodes/20210128-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-01-28
+podname: EINUNDZWANZIG
+topics: Degenerate Finance is not a fraud
+guests: 
+host: 
+abbrev: EUZZ
+sode: 68
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-68-degenerate-finance-is-not-a-fraud/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210204-euzz.md
+++ b/collections/_episodes/20210204-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-02-04
+podname: EINUNDZWANZIG
+topics: Moon-Juice
+guests: 
+host: 
+abbrev: EUZZ
+sode: 69
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-69-moon-juice/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210224-euzz.md
+++ b/collections/_episodes/20210224-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-02-24
+podname: EINUNDZWANZIG
+topics: Ich bin Bitcoiner
+guests: 
+host: 
+abbrev: EUZZ
+sode: 72
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-72-ich-bin-bitcoiner/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210310-euzz.md
+++ b/collections/_episodes/20210310-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-03-10
+podname: EINUNDZWANZIG
+topics: Gratis Satoshis
+guests: 
+host: 
+abbrev: EUZZ
+sode: 74
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-74-gratis-satoshis/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210407-euzz.md
+++ b/collections/_episodes/20210407-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-04-07
+podname: EINUNDZWANZIG
+topics: Hol das Popcorn!
+guests: 
+host: 
+abbrev: EUZZ
+sode: 78
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-78-hol-das-popcorn/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210428-euzz.md
+++ b/collections/_episodes/20210428-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-04-28
+podname: EINUNDZWANZIG
+topics: TINA
+guests: 
+host: 
+abbrev: EUZZ
+sode: 81
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-81-tina/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210512-euzz.md
+++ b/collections/_episodes/20210512-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-05-12
+podname: EINUNDZWANZIG
+topics: Die Pfützen köcheln
+guests: 
+host: 
+abbrev: EUZZ
+sode: 83
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-83-die-pfuetzen-koecheln/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210519-euzz.md
+++ b/collections/_episodes/20210519-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-05-19
+podname: EINUNDZWANZIG
+topics: Unsafe Muun
+guests: 
+host: 
+abbrev: EUZZ
+sode: 84
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-84-unsafe-muun/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210609-euzz.md
+++ b/collections/_episodes/20210609-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-06-09
+podname: EINUNDZWANZIG
+topics: Macht Bitcoin-Babies!
+guests: 
+host: 
+abbrev: EUZZ
+sode: 87
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-87-macht-bitcoin-babies/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210630-euzz.md
+++ b/collections/_episodes/20210630-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-06-30
+podname: EINUNDZWANZIG
+topics: Sommer, Sonne & Satoshi
+guests: 
+host: 
+abbrev: EUZZ
+sode: 90
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-90-sommer-sonne-satoshi/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210721-euzz.md
+++ b/collections/_episodes/20210721-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-07-21
+podname: EINUNDZWANZIG
+topics: Die Legislatoren müssen verrückt sein
+guests: 
+host: 
+abbrev: EUZZ
+sode: 93
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-93-die-legislatoren-muessen-verrueckt-sein/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20210825-euzz.md
+++ b/collections/_episodes/20210825-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-08-25
+podname: EINUNDZWANZIG
+topics: OnlyScams
+guests: 
+host: 
+abbrev: EUZZ
+sode: 96
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-96-onlyscams/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20211020-euzz.md
+++ b/collections/_episodes/20211020-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-10-20
+podname: EINUNDZWANZIG
+topics: Green Dildo ETF
+guests: 
+host: 
+abbrev: EUZZ
+sode: 104
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-104-green-dildo-etf/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20211027-euzz.md
+++ b/collections/_episodes/20211027-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2021-10-27
+podname: EINUNDZWANZIG
+topics: Iris Scanner Dystopie
+guests: 
+host: 
+abbrev: EUZZ
+sode: 105
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-105-iris-scanner-dystopie/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20220101-euzz.md
+++ b/collections/_episodes/20220101-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2022-01-01
+podname: EINUNDZWANZIG
+topics: Lage der Nation - Special
+guests: 
+host: 
+abbrev: EUZZ
+sode: 716426
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/verschiedenes-lage-der-nation-special/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20220304-euzz.md
+++ b/collections/_episodes/20220304-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2022-03-04
+podname: EINUNDZWANZIG
+topics: Value 4 Value Special - Zahlen wir so in Zukunft für Informationen?
+guests: 
+host: 
+abbrev: EUZZ
+sode: 725744
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/verschiedenes-value-4-value-special-zahlen-wir-so-in-zukunft-fuer-informationen/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20220511-euzz.md
+++ b/collections/_episodes/20220511-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2022-05-11
+podname: EINUNDZWANZIG
+topics: Bitcoin oder Shit
+guests: 
+host: 
+abbrev: EUZZ
+sode: 133
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-133-bitcoin-oder-shit/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20220616-euzz.md
+++ b/collections/_episodes/20220616-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2022-06-16
+podname: EINUNDZWANZIG
+topics: Bitcoin ist mein Bergbauernhof
+guests: 
+host: 
+abbrev: EUZZ
+sode: 137
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-137-bitcoin-ist-mein-bergbauernhof/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20221221-euzz.md
+++ b/collections/_episodes/20221221-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2022-12-21
+podname: EINUNDZWANZIG
+topics: 12 Stimmen im Kopf
+guests: 
+host: 
+abbrev: EUZZ
+sode: 164
+star: 
+lang: DE
+code: 
+link: https://einundzwanzig.space/podcast/news-164-12-stimmen-im-kopf/
+podlink: 
+youtube: 
+archive: 
+---

--- a/collections/_episodes/20251221-euzz.md
+++ b/collections/_episodes/20251221-euzz.md
@@ -1,0 +1,17 @@
+---
+layout: page
+date: 2025-12-21
+podname: EINUNDZWANZIG
+topics: Bitcoin, 21, Nostr, and the return of the light
+guests: 
+host: Markus
+abbrev: EUZZ
+sode: 136
+star: 
+lang: DE
+code: light
+link: https://einundzwanzig.space/podcast/interview-136-die-rueckkehr-des-lichts/
+podlink: 
+youtube: 
+archive: 
+---

--- a/media/index.md
+++ b/media/index.md
@@ -44,12 +44,13 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 
 ### Talks
 
-- **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th Sovereign Engineering cohort
+- **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th Sovereign Engineering cohort ([discussion][zap-car-crash-sn])
 - **2021-07-15** - [🇩🇪 Presentation and Panel Discussion][frankfurt-school] at the Frankfurt School Blockchain Center
 - **2020-06-02** - [Keynote: The Bitcoin Journey][vob-bitcoin-journey] at the Value of Bitcoin Conference Digital Europe
 - **2020-05-11** - [Keynote: Competing With Free][vob-competing-with-free] at the Value of Bitcoin Conference Digital America
 
 [zap-car-crash]: https://youtu.be/4usXBGvufKg
+[zap-car-crash-sn]: https://stacker.news/items/927206
 [vob-bitcoin-journey]: https://youtu.be/qVuFX0LkNDQ
 [vob-competing-with-free]: https://youtu.be/JtzwTd9Ur5c
 [frankfurt-school]: https://youtu.be/fx7qftuxyn8

--- a/media/index.md
+++ b/media/index.md
@@ -9,6 +9,10 @@ redirect_from: /interviews
 Note: I won't do any more interviews or other shenanigans until [my 2nd
 book](https://21-ways.com) is done.
 
+These days I host [No Solutions](https://sovereignengineering.io/podcast), a
+podcast about freedom tech, open protocols, and the trade-offs of building in
+the open.
+
 ---
 
 **✨ Recent** | [🧹 All][all] | [⭐ Best][favs] | [🇺🇸 English][en] | [🇩🇪 German][de]
@@ -35,8 +39,6 @@ book](https://21-ways.com) is done.
 In [2019](https://www.blockstream.info/block-height/591121) a couple of
 bitcoiners and I launched [🇩🇪 EINUNDZWANZIG](https://einundzwanzig.space/),
 a German-speaking bitcoin podcast that I am still co-hosting from time to time.
-I also host [No Solutions](https://sovereignengineering.io/podcast), a podcast
-about freedom tech, open protocols, and the trade-offs of building in the open.
 
 ---
 

--- a/media/index.md
+++ b/media/index.md
@@ -35,6 +35,8 @@ book](https://21-ways.com) is done.
 In [2019](https://www.blockstream.info/block-height/591121) a couple of
 bitcoiners and I launched [🇩🇪 EINUNDZWANZIG](https://einundzwanzig.space/),
 a German-speaking bitcoin podcast that I am still co-hosting from time to time.
+I also host [No Solutions](https://sovereignengineering.io/podcast), a podcast
+about freedom tech, open protocols, and the trade-offs of building in the open.
 
 ---
 

--- a/media/index.md
+++ b/media/index.md
@@ -45,12 +45,15 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 ### Talks
 
 - **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th Sovereign Engineering cohort ([discussion][zap-car-crash-sn])
+- **2022-09-03** - [Cryptography is Not Enough][crypto-not-enough] at Baltic Honeybadger in Riga ([transcript][crypto-slides])
 - **2021-07-15** - [🇩🇪 Presentation and Panel Discussion][frankfurt-school] at the Frankfurt School Blockchain Center
 - **2020-06-02** - [Keynote: The Bitcoin Journey][vob-bitcoin-journey] at the Value of Bitcoin Conference Digital Europe
 - **2020-05-11** - [Keynote: Competing With Free][vob-competing-with-free] at the Value of Bitcoin Conference Digital America
 
 [zap-car-crash]: https://youtu.be/4usXBGvufKg
 [zap-car-crash-sn]: https://stacker.news/items/927206
+[crypto-not-enough]: https://youtu.be/C7ynm0Zkwfk
+[crypto-slides]: {{ '/cryptography' | absolute_url }}
 [vob-bitcoin-journey]: https://youtu.be/qVuFX0LkNDQ
 [vob-competing-with-free]: https://youtu.be/JtzwTd9Ur5c
 [frankfurt-school]: https://youtu.be/fx7qftuxyn8

--- a/media/index.md
+++ b/media/index.md
@@ -44,10 +44,12 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 
 ### Talks
 
+- **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th Sovereign Engineering cohort
 - **2021-07-15** - [🇩🇪 Presentation and Panel Discussion][frankfurt-school] at the Frankfurt School Blockchain Center
 - **2020-06-02** - [Keynote: The Bitcoin Journey][vob-bitcoin-journey] at the Value of Bitcoin Conference Digital Europe
 - **2020-05-11** - [Keynote: Competing With Free][vob-competing-with-free] at the Value of Bitcoin Conference Digital America
 
+[zap-car-crash]: https://youtu.be/4usXBGvufKg
 [vob-bitcoin-journey]: https://youtu.be/qVuFX0LkNDQ
 [vob-competing-with-free]: https://youtu.be/JtzwTd9Ur5c
 [frankfurt-school]: https://youtu.be/fx7qftuxyn8

--- a/media/index.md
+++ b/media/index.md
@@ -87,9 +87,12 @@ Some of my writing and speech was [remixed][license] as videos and memes and VR 
 
 ### Twitter Threads
 
-I use twitter to share and distill my thoughts, which sometimes leads to
-long-form twitter threads in which I try to flesh out certain ideas in a more
-public format. Here are some threads that resonated most:
+I used twitter to share and distill my thoughts, which sometimes led to
+long-form twitter threads in which I tried to flesh out certain ideas in a more
+public format. These days I post on [nostr][nostr] instead. Here are some
+threads that resonated most:
+
+[nostr]: {{ '/nostr' | absolute_url }}
 
 - **2021-12-12** - ["Why shitcoins are a waste of your time"][tw-shitcoins-waste-time] - A thread on the winner-takes-all dynamics of Bitcoin.
 - **2021-11-06** - ["Money is a network"][tw-money-network] - A thread on network effects and the design space of money.

--- a/media/index.md
+++ b/media/index.md
@@ -45,6 +45,7 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 ### Talks
 
 - **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th Sovereign Engineering cohort ([discussion][zap-car-crash-sn])
+- **2023-05-11** - [Twentyone.World: A Blueprint for Localized Bitcoin Communities][21world-talk] ([twentyone.world][21world-site])
 - **2022-09-03** - [Cryptography is Not Enough][crypto-not-enough] at Baltic Honeybadger in Riga ([transcript][crypto-slides])
 - **2021-07-15** - [🇩🇪 Presentation and Panel Discussion][frankfurt-school] at the Frankfurt School Blockchain Center
 - **2020-06-02** - [Keynote: The Bitcoin Journey][vob-bitcoin-journey] at the Value of Bitcoin Conference Digital Europe
@@ -54,6 +55,8 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 [zap-car-crash-sn]: https://stacker.news/items/927206
 [crypto-not-enough]: https://youtu.be/C7ynm0Zkwfk
 [crypto-slides]: {{ '/cryptography' | absolute_url }}
+[21world-talk]: https://youtu.be/iOWvL9-4k4A
+[21world-site]: https://twentyone.world/
 [vob-bitcoin-journey]: https://youtu.be/qVuFX0LkNDQ
 [vob-competing-with-free]: https://youtu.be/JtzwTd9Ur5c
 [frankfurt-school]: https://youtu.be/fx7qftuxyn8

--- a/media/index.md
+++ b/media/index.md
@@ -44,7 +44,7 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 
 ### Talks
 
-- **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th Sovereign Engineering cohort ([discussion][zap-car-crash-sn])
+- **2025-06-22** - [You Wouldn't Zap a Car Crash][zap-car-crash], a Tuesday Talk at the 4th [Sovereign Engineering][sov-eng] cohort ([discussion][zap-car-crash-sn])
 - **2023-05-11** - [Twentyone.World: A Blueprint for Localized Bitcoin Communities][21world-talk] ([twentyone.world][21world-site])
 - **2022-09-03** - [Cryptography is Not Enough][crypto-not-enough] at Baltic Honeybadger in Riga ([transcript][crypto-slides])
 - **2021-07-15** - [🇩🇪 Presentation and Panel Discussion][frankfurt-school] at the Frankfurt School Blockchain Center
@@ -53,6 +53,7 @@ a German-speaking bitcoin podcast that I am still co-hosting from time to time.
 
 [zap-car-crash]: https://youtu.be/4usXBGvufKg
 [zap-car-crash-sn]: https://stacker.news/items/927206
+[sov-eng]: https://sovereignengineering.io/
 [crypto-not-enough]: https://youtu.be/C7ynm0Zkwfk
 [crypto-slides]: {{ '/cryptography' | absolute_url }}
 [21world-talk]: https://youtu.be/iOWvL9-4k4A


### PR DESCRIPTION
Refresh the `/media` page with recent podcast appearances and talks, and note that I now host the `No Solutions` podcast in addition to `EINUNDZWANZIG`. The bulk of this adds every `EINUNDZWANZIG` episode I appeared on as individual entries in the `_episodes` collection, with dates and canonical links pulled from the podcast feed so they sort and link correctly.

- Add all `EINUNDZWANZIG` episodes featuring me (German), plus three talks: `You Wouldn't Zap a Car Crash`, `Twentyone.World`, and `Cryptography is Not Enough`
- Mention the `No Solutions` podcast under the note and link `Sovereign Engineering`
- Reword the Twitter threads intro to past tense and point to nostr

Build preview:
- [/media](https://dergigi.com/media)
- [/media/de](https://dergigi.com/media/de)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive episode metadata for the EINUNDZWANZIG podcast, including episodes from 2019 through 2022.
  * Updated the media page with information about the "No Solutions" podcast focused on freedom tech and open protocols.
  * Expanded the talks and media references section with additional dated entries and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->