### PR TITLE
Split /blog and /photography indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dergigi.com
 
-This repository is a collection of thoughts and essays on [Bitcoin](https://dergigi.com/bitcoin/), [life](https://dergigi.com/blog/), and a little bit of [photography](https://dergigi.com/blog/).
+This repository is a collection of thoughts and essays on [Bitcoin](https://dergigi.com/bitcoin/), [life](https://dergigi.com/blog/), and a little bit of [photography](https://dergigi.com/photography/).
 
 If you find any typos, grammatical errors, broken links, or any other mistakes or issues, please [contact me](https://dergigi.com/contact/) and let me know. Or, better yet, create a PR to correct them.
 

--- a/_includes/heart.html
+++ b/_includes/heart.html
@@ -1,3 +1,3 @@
-{% if page.tags contains "Photography" %}💙
+{% if page.category == "blog" %}💙
 {% elsif page.tags contains "nostr" %}💜
 {% else %}🧡{% endif %}

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,6 +1,6 @@
 {% capture thisPost %}{{ page.date | date: "%Y-%m-%d" }}-{{ page.title | slugify }}{% endcapture %}
 {% capture specifiedPath %}{{ include.otherPost }}}{% endcapture %}
-{% capture folderPath %}/assets/images/{{ page.categories[0] | slugify }}/{% if include.otherPost %}{{ include.otherPost }}{% else %}{{ thisPost }}{% endif %}{% endcapture %}
+{% capture folderPath %}/assets/images/photography/{% if include.otherPost %}{{ include.otherPost }}{% else %}{{ thisPost }}{% endif %}{% endcapture %}
 {% capture imagePath %}{% if include.path %}{{ include.path }}{% else %}{{ folderPath }}/{{ include.name }}{% endif %}{% endcapture %}
 <figure>
 {% if include.link %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,7 +17,7 @@ layout: default
           {{ page.date | date: '%-d %b %Y' }}
         {% endif %}
         </time>
-        {% if page.category == "photography" %}
+        {% if page.category == "blog" %}
           <a href="{{ '/blog' | absolute_url }}"
              title="Personal blog entry"
              class="post__source">/blog</a>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-redirect_from: photography
 ---
-{% assign blogposts = site.categories.photography %}
+{% assign blogposts = site.categories.blog %}
 {% include posts-grid.html posts=blogposts %}

--- a/collections/_posts/2018-12-05-wanderers.markdown
+++ b/collections/_posts/2018-12-05-wanderers.markdown
@@ -6,7 +6,7 @@ date: 2018-12-05
 description:
 image: /assets/images/wonderer.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
  - Photography
  - Travel

--- a/collections/_posts/2018-12-07-days-of-gray.markdown
+++ b/collections/_posts/2018-12-07-days-of-gray.markdown
@@ -6,7 +6,7 @@ date: 2018-12-07
 description:
 image: /assets/images/days-of-gray.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2018-12-20-contrasts.markdown
+++ b/collections/_posts/2018-12-20-contrasts.markdown
@@ -6,7 +6,7 @@ date: 2018-12-20
 description:
 image: /assets/images/aurora.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2018-12-26-street-art.markdown
+++ b/collections/_posts/2018-12-26-street-art.markdown
@@ -6,7 +6,7 @@ date: 2018-12-26
 description:
 image: /assets/images/streetart-teresa-gandhi.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-01-05-idling.markdown
+++ b/collections/_posts/2019-01-05-idling.markdown
@@ -6,7 +6,7 @@ date: 2019-01-05
 description:
 image: "/assets/images/idling.jpg"
 author: Gigi
-category: photography
+category: blog
 tags:
 - Photography
 - Travel

--- a/collections/_posts/2019-01-12-remembrance.markdown
+++ b/collections/_posts/2019-01-12-remembrance.markdown
@@ -6,7 +6,7 @@ date: 2019-01-12
 description:
 image: "/assets/images/remembrance.jpg"
 author: Gigi
-category: photography
+category: blog
 tags:
 - Photography
 - Travel

--- a/collections/_posts/2019-02-01-stairs.markdown
+++ b/collections/_posts/2019-02-01-stairs.markdown
@@ -6,7 +6,7 @@ date: 2019-02-01
 description:
 image: /assets/images/sunny-stairs.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
  - Photography
  - Travel

--- a/collections/_posts/2019-02-10-birds.markdown
+++ b/collections/_posts/2019-02-10-birds.markdown
@@ -6,7 +6,7 @@ date: 2019-02-10
 description:
 image: "/assets/images/birds.jpg"
 author: Gigi
-category: photography
+category: blog
 tags:
 - Photography
 - Travel

--- a/collections/_posts/2019-02-19-ducks.markdown
+++ b/collections/_posts/2019-02-19-ducks.markdown
@@ -6,7 +6,7 @@ date: 2019-02-19
 description:
 image: "/assets/images/ducks.jpg"
 author: Gigi
-category: photography
+category: blog
 tags:
 - Photography
 - Travel

--- a/collections/_posts/2019-02-27-outlook.markdown
+++ b/collections/_posts/2019-02-27-outlook.markdown
@@ -6,7 +6,7 @@ date: 2019-02-27
 description:
 image: /assets/images/outlook.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-03-09-waves.markdown
+++ b/collections/_posts/2019-03-09-waves.markdown
@@ -6,7 +6,7 @@ date: 2019-03-09
 description:
 image: /assets/images/waves.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-03-13-paths.markdown
+++ b/collections/_posts/2019-03-13-paths.markdown
@@ -6,7 +6,7 @@ date: 2019-03-13
 description:
 image: /assets/images/paths.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-03-30-dance.markdown
+++ b/collections/_posts/2019-03-30-dance.markdown
@@ -6,7 +6,7 @@ date: 2019-03-30
 description:
 image: /assets/images/dance.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-04-03-strangers.markdown
+++ b/collections/_posts/2019-04-03-strangers.markdown
@@ -6,7 +6,7 @@ date: 2019-04-03
 description:
 image: /assets/images/stranger-artist.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-04-04-happiness.markdown
+++ b/collections/_posts/2019-04-04-happiness.markdown
@@ -6,7 +6,7 @@ date: 2019-04-04
 description:
 image: /assets/images/happiness.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-04-27-calling.markdown
+++ b/collections/_posts/2019-04-27-calling.markdown
@@ -6,7 +6,7 @@ date: 2019-04-27
 description:
 image: /assets/images/calling.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-05-12-ladies.markdown
+++ b/collections/_posts/2019-05-12-ladies.markdown
@@ -6,7 +6,7 @@ date: 2019-05-12
 description:
 image: /assets/images/lady.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-05-21-words.markdown
+++ b/collections/_posts/2019-05-21-words.markdown
@@ -6,7 +6,7 @@ date: 2019-05-21
 description:
 image: /assets/images/words.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-06-08-ships.markdown
+++ b/collections/_posts/2019-06-08-ships.markdown
@@ -6,7 +6,7 @@ date: 2019-06-08
 description:
 image: /assets/images/ship.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-07-09-brevity.markdown
+++ b/collections/_posts/2019-07-09-brevity.markdown
@@ -6,7 +6,7 @@ date: 2019-07-09
 description:
 image: /assets/images/brevity.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-08-25-joy.markdown
+++ b/collections/_posts/2019-08-25-joy.markdown
@@ -6,7 +6,7 @@ date: 2019-08-25
 description:
 image: /assets/images/joy.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Travel

--- a/collections/_posts/2019-11-09-sanity.markdown
+++ b/collections/_posts/2019-11-09-sanity.markdown
@@ -6,7 +6,7 @@ date: 2019-11-09
 description:
 image: /assets/images/sanity.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Wagen-02-07

--- a/collections/_posts/2020-05-31-habits.markdown
+++ b/collections/_posts/2020-05-31-habits.markdown
@@ -6,7 +6,7 @@ date: 2020-05-31
 description:
 image: /assets/images/habits.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Gewohnheiten-02-07

--- a/collections/_posts/2020-06-23-dare.markdown
+++ b/collections/_posts/2020-06-23-dare.markdown
@@ -6,7 +6,7 @@ date: 2020-06-23
 description:
 image: /assets/images/dare.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Wagen-02-07

--- a/collections/_posts/2020-10-04-crushing.markdown
+++ b/collections/_posts/2020-10-04-crushing.markdown
@@ -6,7 +6,7 @@ date: 2020-10-04
 description:
 image: /assets/images/crushing.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Crushing-02-02

--- a/collections/_posts/2020-11-23-creation.markdown
+++ b/collections/_posts/2020-11-23-creation.markdown
@@ -6,7 +6,7 @@ date: 2020-11-23
 description:
 image: /assets/images/creation.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Sch%C3%B6pfung-01-24

--- a/collections/_posts/2021-02-15-humility.markdown
+++ b/collections/_posts/2021-02-15-humility.markdown
@@ -6,7 +6,7 @@ date: 2021-02-15
 description:
 image: /assets/images/humility.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Demut-01-24

--- a/collections/_posts/2021-05-30-seeing.markdown
+++ b/collections/_posts/2021-05-30-seeing.markdown
@@ -6,7 +6,7 @@ date: 2021-05-30
 description:
 image: /assets/images/seeing.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Sehen-01-07

--- a/collections/_posts/2021-09-20-dreams.markdown
+++ b/collections/_posts/2021-09-20-dreams.markdown
@@ -6,7 +6,7 @@ date: 2021-09-20
 description:
 image: /assets/images/dreams.jpg
 author: Gigi
-category: photography
+category: blog
 translations:
  - language: German
    url: https://telegra.ph/Tr%C3%A4ume-01-07

--- a/collections/_posts/2021-09-27-people.markdown
+++ b/collections/_posts/2021-09-27-people.markdown
@@ -6,7 +6,7 @@ date: 2021-09-27
 description:
 image: "/assets/images/people.jpg"
 author: Gigi
-category: photography
+category: blog
 tags:
 - Photography
 translations:

--- a/collections/_posts/2021-12-08-tyranny.markdown
+++ b/collections/_posts/2021-12-08-tyranny.markdown
@@ -6,7 +6,7 @@ date: 2021-12-08
 description:
 image: /assets/images/tyranny.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2022-09-25-creativity.markdown
+++ b/collections/_posts/2022-09-25-creativity.markdown
@@ -8,7 +8,6 @@ image: /assets/images/creativity.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - ai
 ---
 

--- a/collections/_posts/2022-09-25-creativity.markdown
+++ b/collections/_posts/2022-09-25-creativity.markdown
@@ -6,7 +6,7 @@ date: 2022-09-25
 description: What is the root of all creativity?
 image: /assets/images/creativity.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - ai

--- a/collections/_posts/2022-12-28-yesterday.markdown
+++ b/collections/_posts/2022-12-28-yesterday.markdown
@@ -6,7 +6,7 @@ date: 2022-12-28
 description: I'm not half the man I used to be.
 image: /assets/images/yesterday.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
 ---

--- a/collections/_posts/2022-12-28-yesterday.markdown
+++ b/collections/_posts/2022-12-28-yesterday.markdown
@@ -7,8 +7,6 @@ description: I'm not half the man I used to be.
 image: /assets/images/yesterday.jpg
 author: Gigi
 category: blog
-tags:
-  - Photography
 ---
 
 Yesterday was a good day. Today is not.

--- a/collections/_posts/2022-12-29-editing.markdown
+++ b/collections/_posts/2022-12-29-editing.markdown
@@ -6,7 +6,7 @@ date: 2022-12-29
 description: To write is human, to edit is divine.
 image: /assets/images/editing.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
 ---

--- a/collections/_posts/2022-12-29-editing.markdown
+++ b/collections/_posts/2022-12-29-editing.markdown
@@ -7,8 +7,6 @@ description: To write is human, to edit is divine.
 image: /assets/images/editing.jpg
 author: Gigi
 category: blog
-tags:
-  - Photography
 ---
 
 Editing is divine, or so the saying goes.

--- a/collections/_posts/2022-12-29-finishing.markdown
+++ b/collections/_posts/2022-12-29-finishing.markdown
@@ -7,8 +7,6 @@ description: A half-written work is a half-finished love affair.
 image: /assets/images/finishing.jpg
 author: Gigi
 category: blog
-tags:
-  - Photography
 ---
 
 Finishing things is hard. Starting things is easier. Not easy, mind you. But

--- a/collections/_posts/2022-12-29-finishing.markdown
+++ b/collections/_posts/2022-12-29-finishing.markdown
@@ -6,7 +6,7 @@ date: 2022-12-29
 description: A half-written work is a half-finished love affair.
 image: /assets/images/finishing.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
 ---

--- a/collections/_posts/2022-12-30-displays.markdown
+++ b/collections/_posts/2022-12-30-displays.markdown
@@ -6,7 +6,7 @@ date: 2022-12-30
 description: Attention is the currency. Now stare at me.
 image: /assets/images/displays.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
 ---

--- a/collections/_posts/2022-12-30-displays.markdown
+++ b/collections/_posts/2022-12-30-displays.markdown
@@ -7,8 +7,6 @@ description: Attention is the currency. Now stare at me.
 image: /assets/images/displays.jpg
 author: Gigi
 category: blog
-tags:
-  - Photography
 ---
 
 Displays rule our world. They dictate our lives, replace our jobs, facilitate

--- a/collections/_posts/2023-03-08-eggs.markdown
+++ b/collections/_posts/2023-03-08-eggs.markdown
@@ -6,7 +6,7 @@ date: 2023-03-08
 description: Most eggs are still closed. We don't know if they will ever open up. 
 image: /assets/images/eggs.jpg
 author: Gigi
-category: photography
+category: blog
 source: https://read.withboris.com/a/naddr1qqzx2em8wvpzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqvzqqqr4gucv8jqx
 tags:
   - Photography

--- a/collections/_posts/2023-03-08-eggs.markdown
+++ b/collections/_posts/2023-03-08-eggs.markdown
@@ -8,8 +8,6 @@ image: /assets/images/eggs.jpg
 author: Gigi
 category: blog
 source: https://read.withboris.com/a/naddr1qqzx2em8wvpzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqvzqqqr4gucv8jqx
-tags:
-  - Photography
 ---
 
 We didn't hear them land on earth, nor did we see them. The spores were not

--- a/collections/_posts/2023-03-28-hesitancy.markdown
+++ b/collections/_posts/2023-03-28-hesitancy.markdown
@@ -6,7 +6,7 @@ date: 2023-03-28
 description: Hesitancy tells you something.
 image: /assets/images/hesitancy.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2023-03-28-hesitancy.markdown
+++ b/collections/_posts/2023-03-28-hesitancy.markdown
@@ -8,7 +8,6 @@ image: /assets/images/hesitancy.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
 ---
 

--- a/collections/_posts/2023-05-04-writing.markdown
+++ b/collections/_posts/2023-05-04-writing.markdown
@@ -6,7 +6,7 @@ date: 2023-05-04
 description: Writing is one of the most powerful things you can do.
 image: /assets/images/pen.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2023-05-04-writing.markdown
+++ b/collections/_posts/2023-05-04-writing.markdown
@@ -8,7 +8,6 @@ image: /assets/images/pen.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
 ---
 

--- a/collections/_posts/2023-06-04-bees.markdown
+++ b/collections/_posts/2023-06-04-bees.markdown
@@ -6,7 +6,7 @@ date: 2023-06-04
 description: A note on the busyness of bees.
 image: /assets/images/bees.jpg
 author: Gigi
-category: photography
+category: blog
 source: https://read.withboris.com/a/naddr1qqxnzd3cx5urjd35xg6rwwpeqgsxu35yyt0mwjjh8pcz4zprhxegz69t4wr9t74vk6zne58wzh0waycrqsqqqa28pqfh0e
 tags:
   - Photography

--- a/collections/_posts/2023-06-04-bees.markdown
+++ b/collections/_posts/2023-06-04-bees.markdown
@@ -8,8 +8,6 @@ image: /assets/images/bees.jpg
 author: Gigi
 category: blog
 source: https://read.withboris.com/a/naddr1qqxnzd3cx5urjd35xg6rwwpeqgsxu35yyt0mwjjh8pcz4zprhxegz69t4wr9t74vk6zne58wzh0waycrqsqqqa28pqfh0e
-tags:
-  - Photography
 ---
 
 Bees are marvelous creatures. As are most creatures, I guess.

--- a/collections/_posts/2024-02-03-lethargy.markdown
+++ b/collections/_posts/2024-02-03-lethargy.markdown
@@ -8,7 +8,6 @@ image: /assets/images/lethargy.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
 ---
 

--- a/collections/_posts/2024-02-03-lethargy.markdown
+++ b/collections/_posts/2024-02-03-lethargy.markdown
@@ -6,7 +6,7 @@ date: 2024-02-03
 description: "'If you’re not having fun in the bitcoin space you’re doing it wrong.'"
 image: /assets/images/lethargy.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2024-02-04-reality.markdown
+++ b/collections/_posts/2024-02-04-reality.markdown
@@ -8,6 +8,7 @@ image: /assets/images/reality.jpg
 author: Gigi
 category: blog
 tags:
+  - Photography
   - Writing
 ---
 

--- a/collections/_posts/2024-02-04-reality.markdown
+++ b/collections/_posts/2024-02-04-reality.markdown
@@ -6,7 +6,7 @@ date: 2024-02-04
 description: "And life went on. It was not the same, but it went on."
 image: /assets/images/reality.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2024-02-04-reality.markdown
+++ b/collections/_posts/2024-02-04-reality.markdown
@@ -8,7 +8,6 @@ image: /assets/images/reality.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
 ---
 

--- a/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
+++ b/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
@@ -8,7 +8,6 @@ image: /assets/images/suicide.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
   - Personal
 ---

--- a/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
+++ b/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
@@ -6,7 +6,7 @@ date: 2024-11-15
 description: "My dad killed himself today. He hanged himself in the morning."
 image: /assets/images/suicide.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2026-06-15-forgetting.markdown
+++ b/collections/_posts/2026-06-15-forgetting.markdown
@@ -8,7 +8,6 @@ image: /assets/images/forgetting.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
   - Personal
 ---

--- a/collections/_posts/2026-06-15-forgetting.markdown
+++ b/collections/_posts/2026-06-15-forgetting.markdown
@@ -6,7 +6,7 @@ date: 2026-06-15
 description: "Forgetting is a gift. We don't like to forget, but it's a gift nonetheless."
 image: /assets/images/forgetting.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2026-06-17-cancer.markdown
+++ b/collections/_posts/2026-06-17-cancer.markdown
@@ -8,7 +8,6 @@ image: /assets/images/cancer.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
   - Personal
 ---

--- a/collections/_posts/2026-06-17-cancer.markdown
+++ b/collections/_posts/2026-06-17-cancer.markdown
@@ -6,7 +6,7 @@ date: 2026-06-17
 description: "Fuck cancer, sideways, with a rake, forever."
 image: /assets/images/cancer.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2026-06-21-sayings.markdown
+++ b/collections/_posts/2026-06-21-sayings.markdown
@@ -6,7 +6,7 @@ date: 2026-06-21
 description: "Who knows what it's good for."
 image: /assets/images/sayings.jpg
 author: Gigi
-category: photography
+category: blog
 tags:
   - Photography
   - Writing

--- a/collections/_posts/2026-06-21-sayings.markdown
+++ b/collections/_posts/2026-06-21-sayings.markdown
@@ -10,6 +10,7 @@ category: blog
 tags:
   - Writing
   - Personal
+  - ai
 ---
 
 Sayings. My mother loved sayings. She got most of them from _her_ mother, who

--- a/collections/_posts/2026-06-21-sayings.markdown
+++ b/collections/_posts/2026-06-21-sayings.markdown
@@ -8,7 +8,6 @@ image: /assets/images/sayings.jpg
 author: Gigi
 category: blog
 tags:
-  - Photography
   - Writing
   - Personal
 ---

--- a/contact.md
+++ b/contact.md
@@ -46,7 +46,8 @@ Gigi
 
 ## Links
 
-* [/blog][photography]: random thoughts and photographs
+* [/blog](/blog): random thoughts
+* [/photography][photography]: photographs
 * [/bitcoin](/bitcoin): bitcoin stuff
 * [/nostr][nostr]: shitposting, always
 * [/npub][npub]: my current npub
@@ -64,7 +65,7 @@ Gigi
 [bitcoin]: {{ 'bitcoin' | absolute_url }}
 [canary]: {{ 'canary/' | absolute_url }}
 [threads]: {{ 'threads/' | absolute_url }}
-[photography]: {{ 'blog' | absolute_url }}
+[photography]: {{ 'photography' | absolute_url }}
 [gnu]: https://www.gnu.org/philosophy/free-sw.html
 [true-names]: {% post_url /bitcoin/2020-07-21-true-names-not-required %}
 

--- a/photography/index.html
+++ b/photography/index.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+{% assign photoposts = site.posts | where_exp: "p", "p.tags contains 'Photography'" %}
+{% include posts-grid.html posts=photoposts %}

--- a/words.html
+++ b/words.html
@@ -7,6 +7,7 @@ layout: default
     <p>
       You can filter the below via 
       <a href="{{ 'blog' | absolute_url }}">/blog</a>,
+      <a href="{{ 'photography' | absolute_url }}">/photography</a>,
       <a href="{{ 'bitcoin' | absolute_url }}">/bitcoin</a>,
       <a href="{{ 'nostr' | absolute_url }}">/nostr</a>,
       and


### PR DESCRIPTION
Split personal writing and photography into separate indexes. Personal posts now use `category: blog` for `/blog`, while `/photography` lists posts tagged `Photography`. The tag was removed from post-Tyranny essays that no longer use a self-taken cover photo, with exceptions for `Reality` and an `ai` tag added to `Sayings`.

- `/photography` is its own page; `/blog` no longer redirects there
- `Photography` tag kept on posts through Tyranny (2021-12-08), plus `Reality`
- Templates updated: `heart.html`, `image.html`, and site links in `words.html`, `contact.md`, `README.md`

Build preview:
- [/blog](https://dergigi.com/blog)
- [/photography](https://dergigi.com/photography)
- [/sayings](https://dergigi.com/sayings)
