### PR TITLE
fix(images): restore category-based paths in image.html

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,6 +1,12 @@
 {% capture thisPost %}{{ page.date | date: "%Y-%m-%d" }}-{{ page.title | slugify }}{% endcapture %}
 {% capture specifiedPath %}{{ include.otherPost }}}{% endcapture %}
-{% capture folderPath %}/assets/images/photography/{% if include.otherPost %}{{ include.otherPost }}{% else %}{{ thisPost }}{% endif %}{% endcapture %}
+{% assign imageCategory = page.categories[0] | slugify %}
+{% if imageCategory == 'blog' %}
+  {% assign imageCategory = 'photography' %}
+{% elsif imageCategory == 'nostr' %}
+  {% assign imageCategory = 'bitcoin' %}
+{% endif %}
+{% capture folderPath %}/assets/images/{{ imageCategory }}/{% if include.otherPost %}{{ include.otherPost }}{% else %}{{ thisPost }}{% endif %}{% endcapture %}
 {% capture imagePath %}{% if include.path %}{{ include.path }}{% else %}{{ folderPath }}/{{ include.name }}{% endif %}{% endcapture %}
 <figure>
 {% if include.link %}


### PR DESCRIPTION
PR #567 hardcoded `photography` as the image folder in `_includes/image.html`, which broke inline images on bitcoin and nostr posts whose assets live under `assets/images/bitcoin/`. This restores category-based path resolution with two aliases: `blog` → `photography` and `nostr` → `bitcoin`.

- Restore dynamic folder paths in `_includes/image.html` instead of hardcoding `photography`
- Map `blog` posts to the existing `photography` asset folders from before the category rename
- Map `nostr` posts to `bitcoin` where their inline images are stored



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images now load from a category-based directory instead of a single fixed folder, improving image handling across different content sections.
  * Category-specific image paths are selected automatically, with existing fallback behavior for linked and current posts preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->