### PR TITLE
Refine front-page intro closing

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@ layout: default
     </p>
     <p>
       I care about the internet, and what it used to represent. I hope that my
-      kids will be able to enjoy a free and open internet, just like I used to
-      enjoy. I hope that they can express themselves freely, without being forced
+      kids will be able to enjoy a free and open internet, just like I used to.
+      I hope that they can express themselves freely, without being forced
       to use their <a href="{{ '/names' | absolute_url }}">true names</a>. I hope
       that they can escape the eternal doom loop of cheap dopamine and endless
       <a href="https://www.youtube.com/watch?v=4usXBGvufKg">car crashes</a> that
@@ -48,12 +48,16 @@ layout: default
     <p>
       Where do we go from here? I don't know. I will do what I can to help bring
       about a better future. A more prosperous, more stable, more sane future. I
-      am aware that technology isn't everything; it is necessary, but not
-      sufficient. Just like
-      <a href="{{ '/cryptography' | absolute_url }}">cryptography</a>: necessary,
-      but not sufficient. The onus is on us. I believe it is in our power to
+      am aware that technology is not enough, just like
+      <a href="{{ '/cryptography' | absolute_url }}">cryptography is not enough</a>.
+    </p>
+    <p>
+      I believe it is in our power to
       <a href="{{ '/projects/#sovereign-engineering' | absolute_url }}">build
       a better internet</a>: an internet worth having.
+    </p>
+    <p>
+      The onus is on us.
     </p>
     <p>
       Gigi


### PR DESCRIPTION
Refines the closing of the front-page intro. Tightens the "just like I used to" line and reworks the final paragraph into three shorter ones, ending on a punchier "The onus is on us."

- Changes the `cryptography` link text to "cryptography is not enough"
- Splits the closing paragraph so the "build a better internet" line and the closing statement each stand alone

Build preview:
- [/](https://dergigi.com/)
