### PR TITLE
fix: adjust landing page Bitcoin is Time intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: default
       Hi, I'm Gigi.
     </p>
     <p>
-      Most people know me as the author of
+      Most people know me as the guy who wrote
       <a href="{{ '/time' | absolute_url }}">Bitcoin is Time</a>.
     </p>
     <p>


### PR DESCRIPTION
This updates the landing page intro to say `the guy who wrote Bitcoin is Time` instead of `the author of Bitcoin is Time`, matching the wording you requested while leaving the rest of the homepage copy untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the introduction sentence’s wording for a more casual tone while preserving the linked title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->