### PR TITLE
fix: move rss footer icon to end

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,10 +19,10 @@ social:
     url: nostr:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc
   - name: github
     url: https://github.com/dergigi
-  - name: rss
-    url: /feed.xml
   - name: bitcoin
     url: https://dergigi.com/support
+  - name: rss
+    url: /feed.xml
 
 # Collections
 collections_dir: collections


### PR DESCRIPTION
Moves the RSS social entry after the Bitcoin link so the footer renders the RSS icon as the rightmost icon.
