### PR TITLE
Add Thinking in Public RSS feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -58,6 +58,7 @@
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css">
 
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | prepend: site.baseurl }}">
+<link rel="alternate" type="application/rss+xml" title="Thinking in Public" href="{{ '/thoughts.xml' | prepend: site.baseurl }}">
 <link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl }}">
 
 {% if site.google_analytics %}

--- a/collections/_posts/2026-08-19-thinking-in-public.markdown
+++ b/collections/_posts/2026-08-19-thinking-in-public.markdown
@@ -10,6 +10,7 @@ category: blog
 tags:
 - Personal
 - Writing
+- thoughts
 ---
 
 I just took a nice long shower, as I often do, especially when I'm overwhelmed

--- a/thoughts.xml
+++ b/thoughts.xml
@@ -1,0 +1,30 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Thinking in Public</title>
+    <description>Writing to think. Thinking in public.</description>
+    <link>{{ "/thinking" | prepend: site.baseurl | prepend: site.url }}</link>
+    <atom:link href="{{ "/thoughts.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% for post in site.tags.thoughts %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>{{ post.content | xml_escape }}</description>
+        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        {% for tag in post.tags %}
+        <category>{{ tag | xml_escape }}</category>
+        {% endfor %}
+        {% for cat in post.categories %}
+        <category>{{ cat | xml_escape }}</category>
+        {% endfor %}
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
Adds a Thinking in Public RSS feed. Posts opt in with a `thoughts` tag; the first item is the new post.

- New feed at `/thoughts.xml`
- Alternate link in `<head>` titled Thinking in Public
- Tag Thinking in Public as `thoughts`

Build preview: 
- [/thoughts.xml](https://dergigi.com/thoughts.xml)
- [/thinking](https://dergigi.com/thinking)
