### PR TITLE
Tag more posts as thoughts

### DIFF
--- a/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
+++ b/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
@@ -11,6 +11,7 @@ favorite: true
 tags:
   - Writing
   - Personal
+  - thoughts
 ---
 
 > We may enjoy our room in the tower, with the painted walls and the commodious

--- a/collections/_posts/2026-06-15-forgetting.markdown
+++ b/collections/_posts/2026-06-15-forgetting.markdown
@@ -10,6 +10,7 @@ category: blog
 tags:
   - Writing
   - Personal
+  - thoughts
 ---
 
 Forgetting is a gift. We don't like to forget, but it's a gift nonetheless. If

--- a/collections/_posts/2026-06-17-cancer.markdown
+++ b/collections/_posts/2026-06-17-cancer.markdown
@@ -10,6 +10,7 @@ category: blog
 tags:
   - Writing
   - Personal
+  - thoughts
 ---
 
 Cancer.

--- a/collections/_posts/2026-06-21-sayings.markdown
+++ b/collections/_posts/2026-06-21-sayings.markdown
@@ -11,6 +11,7 @@ favorite: true
 tags:
   - Writing
   - Personal
+  - thoughts
 ---
 
 Sayings. My mother loved sayings. She got most of them from _her_ mother, who

--- a/collections/_posts/2026-07-28-typing.markdown
+++ b/collections/_posts/2026-07-28-typing.markdown
@@ -10,6 +10,7 @@ category: blog
 tags:
 - Personal
 - ai
+- thoughts
 boris_link: https://read.withboris.com/a/naddr1qqr8g7tsd9hxwq3qdergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsxpqqqp65w93guky
 ---
 

--- a/collections/_posts/2026-07-30-unfiltered.markdown
+++ b/collections/_posts/2026-07-30-unfiltered.markdown
@@ -10,6 +10,7 @@ category: blog
 tags:
 - Personal
 - Writing
+- thoughts
 boris_link: https://read.withboris.com/a/naddr1qq982mnxd9k8getjv4jqygrwg6zz9hahfftnsup23q3mnv5pdz46hpj4l2ktdpfu6rhpthhwjvpsgqqqw4rsru3nf0
 ---
 

--- a/collections/_posts/2026-08-12-slopocalypse-now.markdown
+++ b/collections/_posts/2026-08-12-slopocalypse-now.markdown
@@ -11,6 +11,7 @@ tags:
 - Personal
 - Writing
 - ai
+- thoughts
 ---
 
 I saw a post yesterday (or was it today? the days have been blurring together


### PR DESCRIPTION
Adds the `thoughts` tag to seven personal posts so they show up in the Thinking in Public feed at `/thoughts.xml`.

- Tag Slopocalypse Now, Unfiltered, Typing, Sayings, Cancer, and Forgetting
- Tag `He Hanged Himself in the Morning`

Build preview: 
- [/thoughts.xml](https://dergigi.com/thoughts.xml)
