### PR TITLE
Fix thought post times and RSS covers

### DIFF
--- a/_includes/feed-item.html
+++ b/_includes/feed-item.html
@@ -1,0 +1,29 @@
+<item>
+  <title>{{ include.post.title | xml_escape }}</title>
+  <description>{{ include.post.content | xml_escape }}</description>
+  <pubDate>{{ include.post.date | date_to_rfc822 }}</pubDate>
+  <link>{{ include.post.url | prepend: site.baseurl | prepend: site.url }}</link>
+  <guid isPermaLink="true">{{ include.post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+  {% if include.post.image %}
+    {% assign image_url = include.post.image | absolute_url %}
+    {% assign image_type = 'image/jpeg' %}
+    {% if include.post.image contains '.png' %}
+      {% assign image_type = 'image/png' %}
+    {% elsif include.post.image contains '.webp' %}
+      {% assign image_type = 'image/webp' %}
+    {% elsif include.post.image contains '.gif' %}
+      {% assign image_type = 'image/gif' %}
+    {% endif %}
+    <media:thumbnail url="{{ image_url }}"/>
+    <media:content url="{{ image_url }}" type="{{ image_type }}" medium="image"/>
+    <enclosure url="{{ image_url }}" type="{{ image_type }}" length="0"/>
+  {% endif %}
+  <content:encoded><![CDATA[{% if include.post.image %}<p><img src="{{ include.post.image | absolute_url }}" alt="{{ include.post.title | xml_escape }}" /></p>
+{% endif %}{{ include.post.content }}]]></content:encoded>
+  {% for tag in include.post.tags %}
+  <category>{{ tag | xml_escape }}</category>
+  {% endfor %}
+  {% for cat in include.post.categories %}
+  <category>{{ cat | xml_escape }}</category>
+  {% endfor %}
+</item>

--- a/bitcoin/feed.xml
+++ b/bitcoin/feed.xml
@@ -2,7 +2,7 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
@@ -12,19 +12,7 @@ layout: null
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for post in site.categories.bitcoin %}
-      <item>
-        <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
-        {% for tag in post.tags %}
-        <category>{{ tag | xml_escape }}</category>
-        {% endfor %}
-        {% for cat in post.categories %}
-        <category>{{ cat | xml_escape }}</category>
-        {% endfor %}
-      </item>
+      {% include feed-item.html post=post %}
     {% endfor %}
   </channel>
 </rss>

--- a/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
+++ b/collections/_posts/2024-11-15-he-hanged-himself-in-the-morning.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "He Hanged Himself in the Morning"
 redirect_from: /suicide
-date: 2024-11-15
+date: 2024-11-15 13:58:34 +0000
 description: "My dad killed himself today. He hanged himself in the morning."
 image: /assets/images/suicide.jpg
 author: Gigi

--- a/collections/_posts/2026-06-15-forgetting.markdown
+++ b/collections/_posts/2026-06-15-forgetting.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Forgetting"
 redirect_from: /forgetting
-date: 2026-06-15
+date: 2026-06-15 13:06:07 +0100
 description: "Forgetting is a gift. We don't like to forget, but it's a gift nonetheless."
 image: /assets/images/forgetting.jpg
 author: Gigi

--- a/collections/_posts/2026-06-17-cancer.markdown
+++ b/collections/_posts/2026-06-17-cancer.markdown
@@ -1,8 +1,10 @@
 ---
 layout: post
 title: "Cancer"
-redirect_from: /cancer
-date: 2026-06-17
+redirect_from:
+  - /cancer
+  - /2026/06/17/cancer/
+date: 2026-06-18 00:07:21 +0100
 description: "Fuck cancer, sideways, with a rake, forever."
 image: /assets/images/cancer.jpg
 author: Gigi

--- a/collections/_posts/2026-06-21-sayings.markdown
+++ b/collections/_posts/2026-06-21-sayings.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Sayings"
 redirect_from: /sayings
-date: 2026-06-21
+date: 2026-06-21 16:53:14 +0200
 description: "Who knows what it's good for."
 image: /assets/images/sayings.jpg
 author: Gigi

--- a/collections/_posts/2026-07-28-typing.markdown
+++ b/collections/_posts/2026-07-28-typing.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: Typing
 redirect_from: "/typing"
-date: 2026-07-28
+date: 2026-07-28 23:20:20 +0200
 description: Less prompting, more typing.
 image: "/assets/images/typing.jpg"
 author: Gigi

--- a/collections/_posts/2026-07-30-unfiltered.markdown
+++ b/collections/_posts/2026-07-30-unfiltered.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: Unfiltered
 redirect_from: "/unfiltered"
-date: 2026-07-30
+date: 2026-07-30 08:16:22 +0200
 description: What should grow is your soul, not their platform.
 image: "/assets/images/unfiltered.jpg"
 author: Gigi

--- a/collections/_posts/2026-08-12-slopocalypse-now.markdown
+++ b/collections/_posts/2026-08-12-slopocalypse-now.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: Slopocalypse Now
 redirect_from: "/slopocalypse"
-date: 2026-08-12
+date: 2026-08-12 12:44:16 +0200
 description: "Fuck this meaningless LLM slop wordsalad dystopia."
 image: "/assets/images/slopocalypse-now.png"
 author: Gigi

--- a/collections/_posts/2026-08-19-thinking-in-public.markdown
+++ b/collections/_posts/2026-08-19-thinking-in-public.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: Thinking in Public
 redirect_from: "/thinking"
-date: 2026-08-19
+date: 2026-08-19 10:03:00 +0200
 description: "Once you start writing for an audience you stop writing for yourself."
 image: "/assets/images/thinking-in-public.jpg"
 author: Gigi

--- a/feed.xml
+++ b/feed.xml
@@ -2,7 +2,7 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
@@ -12,19 +12,7 @@ layout: null
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for post in site.posts %}
-      <item>
-        <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
-        {% for tag in post.tags %}
-        <category>{{ tag | xml_escape }}</category>
-        {% endfor %}
-        {% for cat in post.categories %}
-        <category>{{ cat | xml_escape }}</category>
-        {% endfor %}
-      </item>
+      {% include feed-item.html post=post %}
     {% endfor %}
   </channel>
 </rss>

--- a/scripts/publishtonostr.sh
+++ b/scripts/publishtonostr.sh
@@ -89,7 +89,6 @@ POST_JSON="$("$SCRIPT_DIR/jekyll_frontmatter.rb" read "$POST_FILE")"
 TITLE="$(jq -r '.front_matter.title // empty' <<<"$POST_JSON")"
 DESC="$(jq -r '.front_matter.description // empty' <<<"$POST_JSON")"
 IMAGE_RAW="$(jq -r '.front_matter.image // empty' <<<"$POST_JSON")"
-DATE_RAW="$(jq -r '.front_matter.date // empty' <<<"$POST_JSON")"
 CATEGORY="$(jq -r '.front_matter.category // empty' <<<"$POST_JSON")"
 TAGS_JSON="$(jq -c '(.front_matter.tags // []) | map(tostring)' <<<"$POST_JSON")"
 BODY_RAW="$(jq -r '.body' <<<"$POST_JSON")"
@@ -227,8 +226,18 @@ BODY="$(echo "$BODY_RAW" | sed -E 's/<cite[^>]*>/—/g' | sed -E 's/<\/cite>//g'
 # Convert double backslashes (markdown line breaks) to two spaces + newline
 BODY="$(echo "$BODY" | perl -pe 's/\\\\$/  /')"
 
-# Use date from front matter or filename
-DATE_STR="${DATE_RAW:-$YEAR-$MONTH-$DAY}"
+# Use the literal date: line. YAML treats naive datetimes as UTC, then
+# JSON dumps them in local time, which shifts published_at by the offset
+# (e.g. 17:42 becomes 19:42 +0200). A date with an offset is used as-is.
+# A naive time or a date-only value is parsed in the local timezone.
+DATE_STR="$(ruby -e '
+  File.foreach(ARGV[0]) do |line|
+    next unless line =~ /\Adate:\s+(.+?)\s*\z/
+    puts $1.gsub(/\A["\x27]|["\x27]\z/, "")
+    break
+  end
+' "$POST_FILE")"
+DATE_STR="${DATE_STR:-$YEAR-$MONTH-$DAY}"
 PUBLISHED_AT="$(ruby -e 'require "time"; puts Time.parse(ARGV[0]).to_i' "$DATE_STR" 2>/dev/null || echo "")"
 
 if [[ -z "$PUBLISHED_AT" ]]; then

--- a/thoughts.xml
+++ b/thoughts.xml
@@ -2,7 +2,7 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>Thinking in Public</title>
     <description>Writing to think. Thinking in public.</description>
@@ -12,19 +12,7 @@ layout: null
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for post in site.tags.thoughts %}
-      <item>
-        <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
-        {% for tag in post.tags %}
-        <category>{{ tag | xml_escape }}</category>
-        {% endfor %}
-        {% for cat in post.categories %}
-        <category>{{ cat | xml_escape }}</category>
-        {% endfor %}
-      </item>
+      {% include feed-item.html post=post %}
     {% endfor %}
   </channel>
 </rss>


### PR DESCRIPTION
Fixes publish times on the thought posts and puts cover images in the RSS feeds. Also stops the Nostr script from shifting naive datetimes when it builds `published_at`.

- Set frontmatter times from git history, including `10:03 +0200` on Thinking in Public
- Parse the literal `date:` line in `publishtonostr.sh`
- Add Media RSS and `content:encoded` covers via `_includes/feed-item.html`

Build preview: 
- [/thoughts.xml](https://dergigi.com/thoughts.xml)
- [/feed.xml](https://dergigi.com/feed.xml)
- [/thinking](https://dergigi.com/thinking)
