### PR TITLE
Fix relative links and blog images in publishtonostr

### DIFF
--- a/collections/_posts/2026-08-20-grug-speak-grug-outside-grug-happy.markdown
+++ b/collections/_posts/2026-08-20-grug-speak-grug-outside-grug-happy.markdown
@@ -2,8 +2,8 @@
 layout: post
 title: Grug Speak, Grug Outside, Grug Happy
 redirect_from: "/grug"
-date: 2026-08-20 22:13:00 +0200
-description: "Build, sign, push, done."
+date: 2026-08-20 22:13:00.000000000 +02:00
+description: Build, sign, push, done.
 image: "/assets/images/grug-happy.jpg"
 author: Gigi
 category: blog
@@ -11,6 +11,7 @@ tags:
 - thoughts
 - nostr
 - ai
+boris_link: https://read.withboris.com/a/naddr1qq3xwun4vukhxur9v94j6emjw4nj6mm4w3ekjer994nhyat8945xzurs0ypzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqvzqqqr4gueccs3v
 ---
 
 Before my [thinkboi](/speech) days I used to be a developer. Writing code instead

--- a/scripts/publishtonostr.sh
+++ b/scripts/publishtonostr.sh
@@ -117,15 +117,17 @@ SLUG="${SLUG_EXT%.*}"
 # Build post identifier for image paths (YYYY-MM-DD-slug)
 POST_ID="${YEAR}-${MONTH}-${DAY}-${SLUG}"
 
-# Map category for image paths (nostr -> bitcoin)
+# Map category for image paths to match _includes/image.html
 IMAGE_CATEGORY="$CATEGORY"
-if [[ "$CATEGORY" == "nostr" ]]; then
+if [[ "$CATEGORY" == "blog" ]]; then
+  IMAGE_CATEGORY="photography"
+elif [[ "$CATEGORY" == "nostr" ]]; then
   IMAGE_CATEGORY="bitcoin"
 fi
 
 # Convert Jekyll image includes to Markdown
 # {% include image.html name="image.jpg" [caption="..."] %} -> ![](absolute-url-to-image)
-# The Jekyll include builds path as: /assets/images/{category}/{post-id}/{name}
+# The Jekyll include builds path as: /assets/images/{image-category}/{post-id}/{name}
 if [[ -n "$IMAGE_CATEGORY" ]]; then
   BODY_RAW="$(echo "$BODY_RAW" | perl -pe "
     s|{% include image\.html name=\"([^\"]+)\"[^}]*%}|![](${SITE_URL}/assets/images/${IMAGE_CATEGORY}/${POST_ID}/\$1)|g

--- a/scripts/publishtonostr.sh
+++ b/scripts/publishtonostr.sh
@@ -177,7 +177,7 @@ BODY_RAW="$(echo "$BODY_RAW" | perl -ne '
 # ![alt](/path/to/image.jpg#full) -> ![alt](https://site.com/path/to/image.jpg)
 # ![alt](/path/to/video.mp4#full) -> ![alt](https://site.com/path/to/video.mp4)
 # Skip URLs that are already absolute (start with http:// or https://)
-BODY_RAW="$(SITE_URL="$SITE_URL" echo "$BODY_RAW" | perl -pe '
+BODY_RAW="$(echo "$BODY_RAW" | SITE_URL="$SITE_URL" perl -pe '
   BEGIN { $site = $ENV{SITE_URL}; }
   s|!\[([^\]]*)\]\(([^)]+)\)|do { my ($alt, $url) = ($1, $2); sprintf("![%s](%s)", $alt, ($url =~ m{^https?://}) ? $url : ((substr($url, 0, 1) eq "/") ? $site . $url : $site . "/" . $url)); }|ge
 ')"
@@ -206,7 +206,7 @@ BODY_RAW="$(echo "$BODY_RAW" | perl -ne '
 # [text](/path) -> [text](https://site.com/path)
 # [text](/path#anchor) -> [text](https://site.com/path#anchor)
 # Don't convert absolute links (http/https)
-BODY_RAW="$(SITE_URL="$SITE_URL" echo "$BODY_RAW" | perl -pe '
+BODY_RAW="$(echo "$BODY_RAW" | SITE_URL="$SITE_URL" perl -pe '
   BEGIN { $site = $ENV{SITE_URL}; }
   s|\[([^\]]+)\]\(([^)]+)\)|do { my ($text, $url) = ($1, $2); sprintf("[%s](%s)", $text, ($url =~ m{^https?://}) ? $url : (substr($url, 0, 1) eq "/" ? $site . $url : $site . "/" . $url)); }|ge
 ')"


### PR DESCRIPTION
Fixes `publishtonostr.sh` so Nostr copies of posts get real `https://dergigi.com` URLs. Relative markdown links were left as `/speech` because `SITE_URL` never reached perl, and blog image includes pointed at `/assets/images/blog/` instead of `photography`.

- Pass `SITE_URL` to perl when rewriting links and images
- Map `blog` image includes to `photography`, matching `_includes/image.html`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Boris reader link to the Grug blog post.
  * Updated post metadata for improved date and description formatting.

* **Bug Fixes**
  * Improved image and link handling when publishing posts to Nostr.
  * Blog images now use the appropriate photography category, while Nostr images continue using the Bitcoin category.
  * Corrected site URL substitution for published Markdown images and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->