### PR TITLE
Add NIP-21 nostr author and alternate tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,6 +32,26 @@
 {% capture lightningAddress %}{% if shortName != '' %}{{ shortName }}{% else %}{{ 's' }}{% endif %}@ts.dergigi.com{% endcapture %}
 <meta name="lightning" content="lnurlp:{{ lightningAddress }}"/>
 
+<!-- NIP-21: let nostr apps discover the author and the nostr version of a page -->
+{% assign nostr_uri = nil %}
+{% for social in site.social %}
+  {% if social.name == "nostr" %}
+    {% assign nostr_uri = social.url %}
+  {% endif %}
+{% endfor %}
+{% if nostr_uri %}
+<link rel="me" href="{{ nostr_uri }}">
+{% if page.layout == "post" %}
+<link rel="author" href="{{ nostr_uri }}">
+{% endif %}
+{% endif %}
+{% if page.boris_link %}
+  {% assign nostr_entity = page.boris_link | split: '/' | last | split: '?' | first | remove_first: 'nostr:' %}
+  {% if nostr_entity contains 'naddr1' or nostr_entity contains 'nevent1' or nostr_entity contains 'note1' %}
+<link rel="alternate" href="nostr:{{ nostr_entity }}">
+  {% endif %}
+{% endif %}
+
 <!-- Twitter cards -->
 <meta name="twitter:site"    content="@{{ site.title }}">
 <meta name="twitter:creator" content="@{{ site.twitter_username }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -47,7 +47,10 @@
 {% endif %}
 {% if page.boris_link %}
   {% assign nostr_entity = page.boris_link | split: '/' | last | split: '?' | first | remove_first: 'nostr:' %}
-  {% if nostr_entity contains 'naddr1' or nostr_entity contains 'nevent1' or nostr_entity contains 'note1' %}
+  {% assign nostr_naddr = nostr_entity | slice: 0, 6 %}
+  {% assign nostr_nevent = nostr_entity | slice: 0, 7 %}
+  {% assign nostr_note = nostr_entity | slice: 0, 5 %}
+  {% if nostr_naddr == 'naddr1' or nostr_nevent == 'nevent1' or nostr_note == 'note1' %}
 <link rel="alternate" href="nostr:{{ nostr_entity }}">
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Adds NIP-21 `<link>` tags so nostr apps can pick up the site npub and, when a post has a `boris_link`, the matching nostr event.

- `rel="me"` on every page, using the npub from `site.social`
- `rel="author"` on posts
- `rel="alternate"` with `nostr:naddr` / `nevent` / `note` extracted from `boris_link`

Closes #595


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nostr metadata to identify the site and post authors.
  * Added support for linking recognized Nostr entities through alternate metadata.
  * Improved compatibility with Nostr clients and services by exposing valid Nostr URLs.
* **Bug Fixes**
  * Improved Nostr entity validation to recognize only identifiers with supported prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->